### PR TITLE
Fix EngineTests.swift.

### DIFF
--- a/Tests/SubstrataTests/EngineTests.swift
+++ b/Tests/SubstrataTests/EngineTests.swift
@@ -146,7 +146,7 @@ class EngineTests: XCTestCase {
         XCTAssertTrue(r is AnalyticsJS)
         
         let o = engine.object(key: "a")?.typed(JSObject.self)
-        XCTAssertNotNil(o)
+        XCTAssertNil(o)
         
         let result = engine.evaluate(script: "var annie = new Analytics('9876'); annie.track('booya');")
         XCTAssertNil(result)


### PR DESCRIPTION
Simple fix for EngineTests.swift that confirm JSObject is not a super class of AnalyticsJS.