### PR TITLE
Allow an evaluator to be set.

### DIFF
--- a/Sources/Substrata/DataBridge.swift
+++ b/Sources/Substrata/DataBridge.swift
@@ -50,6 +50,6 @@ extension JSDataBridge {
         // we already have one fool!
         if self.engine != nil { return }
         self.engine = engine
-        engine.evaluate(script: "var \(JSDataBridge.dataBridgeKey) = {};")
+        engine.evaluate(script: "var \(JSDataBridge.dataBridgeKey) = {};", evaluator: "JSDataBridge.setEngine")
     }
 }

--- a/Sources/Substrata/Engine.swift
+++ b/Sources/Substrata/Engine.swift
@@ -61,6 +61,11 @@ public class JSEngine {
         
         completion?(jsError)
     }
+    
+    @discardableResult
+    public func evaluate(script: String) -> JSConvertible? {
+        return evaluate(script: script, evaluator: Constants.Evaluator)
+    }
 
     /// Evaluates a script and returns a result.
     ///
@@ -68,12 +73,11 @@ public class JSEngine {
     ///     - script: The script to evaluate
     ///     - evaluator: An optional identifying name of the evaluator, useful in debugging.
     @discardableResult
-    public func evaluate(script: String, evaluator: String? = nil) -> JSConvertible? {
+    public func evaluate(script: String, evaluator: String) -> JSConvertible? {
         var outerResult: JSConvertible? = nil
-        let evalName = evaluator ?? Constants.Evaluator
         context.performThreadSafe { [weak self] in
             guard let self else { return }
-            let result = JS_Eval(context.ref, script, script.lengthOfBytes(using: .utf8), evalName, 0)
+            let result = JS_Eval(context.ref, script, script.lengthOfBytes(using: .utf8), evaluator, 0)
             outerResult = result.toJSConvertible(context: context)
             result.free(context)
         }

--- a/Sources/Substrata/Engine.swift
+++ b/Sources/Substrata/Engine.swift
@@ -56,18 +56,24 @@ public class JSEngine {
         }
             
         if let jsSource = jsSource {
-            evaluate(script: jsSource)
+            evaluate(script: jsSource, evaluator: "JSEngine.loadBundle")
         }
         
         completion?(jsError)
     }
 
+    /// Evaluates a script and returns a result.
+    ///
+    /// params:
+    ///     - script: The script to evaluate
+    ///     - evaluator: An optional identifying name of the evaluator, useful in debugging.
     @discardableResult
-    public func evaluate(script: String) -> JSConvertible? {
+    public func evaluate(script: String, evaluator: String? = nil) -> JSConvertible? {
         var outerResult: JSConvertible? = nil
+        let evalName = evaluator ?? Constants.Evaluator
         context.performThreadSafe { [weak self] in
             guard let self else { return }
-            let result = JS_Eval(context.ref, script, script.lengthOfBytes(using: .utf8), Constants.Evaluator, 0)
+            let result = JS_Eval(context.ref, script, script.lengthOfBytes(using: .utf8), evalName, 0)
             outerResult = result.toJSConvertible(context: context)
             result.free(context)
         }
@@ -86,7 +92,7 @@ public class JSEngine {
     
     public func value(for keyPath: String) -> JSConvertible? {
         guard keyPath.count > 0 else { return nil }
-        let result = evaluate(script: keyPath)
+        let result = evaluate(script: keyPath, evaluator: "JSEngine.value")
         return result
     }
     

--- a/Sources/Substrata/Objects/Builtins.swift
+++ b/Sources/Substrata/Objects/Builtins.swift
@@ -36,9 +36,9 @@ internal class Builtins {
           }
           return output;
         }
-        """)
+        """, evaluator: "JSEngine.Builtins")
         
-        if let getInstanceMethodNames = engine.evaluate(script: "_getInstanceMethodNames")?.typed(as: JSFunction.self) {
+        if let getInstanceMethodNames = engine.evaluate(script: "_getInstanceMethodNames", evaluator: "JSEngine.Builtins.evaluate")?.typed(as: JSFunction.self) {
             functions["_getInstanceMethodNames"] = getInstanceMethodNames
         }
     }


### PR DESCRIPTION
- Added an evaluate method to allow an evaluator to be specified.
- Evaluator name is useful in debugging when determining the source of an error.