### PR TITLE
Added failable funtions/constructors/getters/setters

### DIFF
--- a/Sources/Substrata/Internals/Context.swift
+++ b/Sources/Substrata/Internals/Context.swift
@@ -71,6 +71,16 @@ internal class JSContext {
 }
 
 extension JSContext {
+    func throwError(_ error: Error) -> JSValue {
+        let jsError = JSError.from(error)
+        if let errorValue = jsError.toJSValue(context: self) {
+            return JS_Throw(self.ref, errorValue)
+        }
+        return JS_Throw(self.ref, JS_NewError(self.ref))
+    }
+}
+
+extension JSContext {
     func newContextClassID() -> Int32 {
         return exportLock.perform {
             let new = classCounter

--- a/Sources/Substrata/Internals/InternalTypes.swift
+++ b/Sources/Substrata/Internals/InternalTypes.swift
@@ -40,7 +40,7 @@ internal class JSClassInfo {
 
 internal class JSClassInstanceInfo {
     let classID: JSClassID
-    weak var instance: JSExport?
+    var instance: JSExport?
     let type: JSExport.Type
     
     init(type: JSExport.Type, classID: JSClassID, instance: JSExport?) {

--- a/Sources/Substrata/Types.swift
+++ b/Sources/Substrata/Types.swift
@@ -30,14 +30,14 @@ extension JSConvertible {
     }
 }
 
-public typealias JSFunctionDefinition = ([JSConvertible?]) -> JSConvertible?
+public typealias JSFunctionDefinition = ([JSConvertible?]) throws -> JSConvertible?
 
 public protocol JSStatic {
     static func staticInit()
 }
 
-public typealias JSPropertyGetterDefinition = () -> JSConvertible?
-public typealias JSPropertySetterDefinition = (JSConvertible?) -> Void
+public typealias JSPropertyGetterDefinition = () throws -> JSConvertible?
+public typealias JSPropertySetterDefinition = (JSConvertible?) throws -> Void
 
 public class JSProperty {
     internal let getter: JSPropertyGetterDefinition
@@ -109,7 +109,7 @@ open class JSExport {
         }
         let wrappedFunction: JSFunctionDefinition = { [weak self] args in
             guard self != nil else { return nil }
-            return function(args)  // function captures 'self' strongly, but our wrapper holds it weakly
+            return try function(args)  // function captures 'self' strongly, but our wrapper holds it weakly
         }
         
         _exportedMethods[named] = wrappedFunction
@@ -135,5 +135,5 @@ open class JSExport {
     
     // Overrides
     public required init() {}
-    open func construct(args: [JSConvertible?]) {}
+    open func construct(args: [JSConvertible?]) throws {}
 }

--- a/Tests/SubstrataTests/ConversionTests.swift
+++ b/Tests/SubstrataTests/ConversionTests.swift
@@ -18,6 +18,55 @@ final class ConversionTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         EdgeFunctionJS.reset()
     }
+    
+    func testNativeThrowingConstructor() throws {
+        let engine = JSEngine()
+        var exceptionHit = false
+        engine.exceptionHandler = { error in
+            exceptionHit = true
+            print(error.jsDescription())
+        }
+        
+        engine.export(type: ThrowingConstructorJS.self, className:"ThrowingConstructor")
+        
+        // test constructor
+        let r = engine.evaluate(script: "let x = new ThrowingConstructor(true);")
+        XCTAssertNotNil(r)
+        XCTAssertTrue(exceptionHit)
+    }
+    
+    func testNativeThrowingOtherStuff() throws {
+        let engine = JSEngine()
+        var exceptionHit = false
+        engine.exceptionHandler = { error in
+            exceptionHit = true
+            print(error.jsDescription())
+        }
+        
+        engine.export(type: ThrowingConstructorJS.self, className: "ThrowingConstructor")
+        
+        // test function
+        exceptionHit = false
+        var r = engine.evaluate(script: "let y = new ThrowingConstructor(false);")
+        XCTAssertNil(r)
+        let b = engine.evaluate(script: "y.noThrowFunc()")?.typed(as: Int.self)
+        XCTAssertEqual(b, 3)
+        r = engine.evaluate(script: "y.throwFunc()")
+        XCTAssertNotNil(r)
+        XCTAssertTrue(exceptionHit)
+        
+        // test getter
+        exceptionHit = false
+        r = engine.evaluate(script: "y.throwProp")
+        XCTAssertNotNil(r)
+        XCTAssertTrue(exceptionHit)
+        
+        // test setter
+        exceptionHit = false
+        r = engine.evaluate(script: "y.throwProp = 5")
+        XCTAssertNotNil(r)
+        XCTAssertTrue(exceptionHit)
+    }
 
     func testMassConversionOut() throws {
         let engine = JSEngine()

--- a/Tests/SubstrataTests/SubstrataTests.swift
+++ b/Tests/SubstrataTests/SubstrataTests.swift
@@ -59,6 +59,9 @@ class MyJSClass: JSExport, JSStatic {
         super.init()
         
         exportMethod(named: "test", function: test)
+        exportMethod(named: "test2", function: { args in
+            return 3
+        })
         
         exportProperty(named: "myInstanceProperty", getter: {
             return self.myInstanceProperty
@@ -205,6 +208,18 @@ final class SubstrataTests: XCTestCase {
             
         let result = v?.call(method: "test", args: nil)?.typed(as: Int.self)
         XCTAssertEqual(result, 1337)
+    }
+    
+    func testExportInstanceMethod() {
+        let engine = JSEngine()
+        
+        engine.export(type: MyJSClass.self, className: "MyJSClass")
+        engine.evaluate(script: "let x = new MyJSClass()")
+        var result = engine.evaluate(script: "x.test()")?.typed(as: Int.self)
+        XCTAssertEqual(result, 42)
+        
+        result = engine.evaluate(script: "x.test2()")?.typed(as: Int.self)
+        XCTAssertEqual(result, 3)
     }
     
     func testStaticProperties() {

--- a/Tests/SubstrataTests/Support/Mocks.swift
+++ b/Tests/SubstrataTests/Support/Mocks.swift
@@ -8,6 +8,45 @@
 import Foundation
 @testable import Substrata
 
+class ThrowingConstructorJS: JSExport, JSStatic {
+    static func staticInit() {
+        
+    }
+    
+    enum ErrorTest: String, Error {
+        case constructor
+        case function
+        case getter
+        case setter
+    }
+    
+    required init() {
+        super.init()
+        
+        exportMethod(named: "noThrowFunc") { args in
+            print("noThrowFunc")
+            return 3
+        }
+        
+        exportMethod(named: "throwFunc") { args in
+            print("throwFunc")
+            throw ErrorTest.function
+        }
+        
+        exportProperty(named: "throwProp") {
+            throw ErrorTest.getter
+        } setter: { value in
+            throw ErrorTest.setter
+        }
+    }
+    
+    override func construct(args: [JSConvertible?]) throws {
+        if let shouldThrow = args.first as? Bool, shouldThrow {
+            throw ErrorTest.constructor
+        }
+    }
+}
+
 class EdgeFunctionJS: JSExport, JSStatic {
     static var myStaticBool: Bool? = true
     var myBool: Bool? = false

--- a/Tests/SubstrataTests/TypeTests.swift
+++ b/Tests/SubstrataTests/TypeTests.swift
@@ -91,8 +91,8 @@ final class TypeTests: XCTestCase {
         let r = engine.evaluate(script: "Error('test')")?.typed(as: JSError.self)!
         XCTAssertNotNil(r)
         let out = r!.toJSValue(context: engine.context)
-        // we won't make an error on the native side.
-        XCTAssertNil(out)
+        // we WILL make an error on the native side.
+        XCTAssertNotNil(out)
     }
 
     func testInt() throws {


### PR DESCRIPTION
- Added ability for constructors, methods, getters, setters and functions to throw internally similar to JS implementations.
- Added ability for JSError's to be created on the native side and interop with JS.
- Fixed potential retain issue with native class instances.
- Added mocks and tests.